### PR TITLE
Allow setting the I2C address register as kwarg

### DIFF
--- a/adafruit_tlv493d.py
+++ b/adafruit_tlv493d.py
@@ -59,6 +59,7 @@ class TLV493D:
 
     :param busio.I2C i2c_bus: The I2C bus the TLV493D is connected to.
     :param int address: The I2C address of the TLV493D. Defaults to 0x5E.
+    :param int addr_reg: Initial value of the I2C address register. Defaults to 0.
 
     """
 
@@ -93,13 +94,16 @@ class TLV493D:
         "RES3": (3, 0x1F, 0),
     }
 
-    def __init__(self, i2c_bus, address=_TLV493D_DEFAULT_ADDRESS):
+    def __init__(self, i2c_bus, address=_TLV493D_DEFAULT_ADDRESS, addr_reg=0):
         self.i2c_device = i2cdevice.I2CDevice(i2c_bus, address)
         self.read_buffer = bytearray(10)
         self.write_buffer = bytearray(4)
 
         # read in data from sensor, including data that must be set on a write
         self._setup_write_buffer()
+
+        # write correct i2c address
+        self._set_write_key("ADDR", addr_reg)
 
         # setup MASTERCONTROLLEDMODE which takes a measurement for every read
         self._set_write_key("PARITY", 1)


### PR DESCRIPTION
With the kwarg `addr_reg`, multiple sensors can be used on one bus without fiddling with the ADDR/SDA line. The sensors ADDR register is set to its value upon initialization. 

Each sensors VCC has to be connected to a GPIO pin. Sensors can then be enabled one by one, setting a new address each time. Up to 4 sensors can be used on one bus this way.

Example, VCC of TLV493Ds connected to D4 and D17:
```Python
en_pin = digitalio.DigitalInOut(board.D4)
en_pin.switch_to_output()

en2_pin = digitalio.DigitalInOut(board.D17)
en2_pin.switch_to_output()

i2c = busio.I2C(board.SCL, board.SDA)

en_pin.value = False
en2_pin.value = False
time.sleep(0.2)

en_pin.value = True

tlv = adafruit_tlv493d.TLV493D(i2c, addr_reg=1)
tlv = adafruit_tlv493d.TLV493D(i2c, address=0x5a, addr_reg=1)

en2_pin.value = True
tlv2 = adafruit_tlv493d.TLV493D(i2c, addr_reg=3)
tlv2 = adafruit_tlv493d.TLV493D(i2c, address=0x4a, addr_reg=3)
```

It's surely not as nice of an API as it could be, but I didn't really have a better idea on an easy way to get multiple sensors working.