### PR TITLE
Update adafruit_tlv493d.py

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -69,7 +69,7 @@ Usage Example
     tlv = adafruit_tlv493d.TLV493D(i2c)
 
     while True:
-        print("X: %s, Y:%s, Z:%s mT"%tlv.magnetic)
+        print("X: %s, Y:%s, Z:%s uT"%tlv.magnetic)
         time.sleep(1)
 
 Documentation

--- a/adafruit_tlv493d.py
+++ b/adafruit_tlv493d.py
@@ -158,7 +158,7 @@ class TLV493D:
     @property
     def magnetic(self) -> Tuple[float, float, float]:
         """The processed magnetometer sensor values.
-        A 3-tuple of X, Y, Z axis values in milliteslas that are signed floats.
+        A 3-tuple of X, Y, Z axis values in microteslas that are signed floats.
         """
         self._read_i2c()  # update read registers
         x_top = self._get_read_key("BX1")
@@ -178,4 +178,4 @@ class TLV493D:
     def _unpack_and_scale(top: int, bottom: int) -> float:
         binval = struct.unpack_from(">h", bytearray([top, bottom]))[0]
         binval = binval >> 4
-        return binval * 0.098
+        return binval * 98.0

--- a/adafruit_tlv493d.py
+++ b/adafruit_tlv493d.py
@@ -158,7 +158,7 @@ class TLV493D:
     @property
     def magnetic(self) -> Tuple[float, float, float]:
         """The processed magnetometer sensor values.
-        A 3-tuple of X, Y, Z axis values in microteslas that are signed floats.
+        A 3-tuple of X, Y, Z axis values in milliteslas that are signed floats.
         """
         self._read_i2c()  # update read registers
         x_top = self._get_read_key("BX1")

--- a/examples/tlv493d_simpletest.py
+++ b/examples/tlv493d_simpletest.py
@@ -9,5 +9,5 @@ i2c = board.I2C()  # uses board.SCL and board.SDA
 tlv = adafruit_tlv493d.TLV493D(i2c)
 
 while True:
-    print("X: %s, Y: %s, Z: %s mT" % tlv.magnetic)
+    print("X: %s, Y: %s, Z: %s uT" % tlv.magnetic)
     time.sleep(1)


### PR DESCRIPTION
Fixed units in docstring. Alternatively, multiply the returned values by 1000 in `_unpack_and_scale` to report microteslas (what all the other magnetic sensors from adafruit report).